### PR TITLE
remove sa.aboutdavid.me

### DIFF
--- a/unethical-web-analytics.txt
+++ b/unethical-web-analytics.txt
@@ -1626,7 +1626,6 @@
 ||sa.810antiques.com^
 ||sa.abilian.com^
 ||sa.abla.ge^
-||sa.aboutdavid.me^
 ||sa.abriefhistoryofyesterday.com^
 ||sa.academie.dev^
 ||sa.acdye.com^


### PR DESCRIPTION
Simple Analytics is **not** unethical. It appears that you have taken no time to even look into simple analytics and to block them. They don't use cookies at all and all things tracked is anonymous .